### PR TITLE
Added-example

### DIFF
--- a/doc/ModelCode.md
+++ b/doc/ModelCode.md
@@ -267,7 +267,7 @@ g.field 'Select an Ad', 'ad_selection', type: 'select'
   .option 'Ad 1'
   .option 'Ad 2'
 
-g.field 'Ad Title', 'ad_title', value: "Default title
+g.field 'Ad Title', 'ad_title', value: "Default title"
 
 g.field 'Change Ad title to default', 'changeValue', type: 'button', tooltip: 'Click here to change ad title to default',
   onClick: ->

--- a/doc/ModelCode.md
+++ b/doc/ModelCode.md
@@ -267,6 +267,12 @@ g.field 'Select an Ad', 'ad_selection', type: 'select'
   .option 'Ad 1'
   .option 'Ad 2'
 
+g.field 'Ad Title', 'ad_title', value: "Default title
+
+g.field 'Change Ad title to default', 'changeValue', type: 'button', tooltip: 'Click here to changhe ad title to default',
+  onClick: ->
+    g.child('ad_selection').value = "Milk Duds 2019"
+
 g.field 'Edit', 'edit', type: 'button', tooltip: 'Click here to edit the selected ad',
   onClick: ->
     emit 'edit_ad', value: g.child('ad_selection').value

--- a/doc/ModelCode.md
+++ b/doc/ModelCode.md
@@ -269,9 +269,9 @@ g.field 'Select an Ad', 'ad_selection', type: 'select'
 
 g.field 'Ad Title', 'ad_title', value: "Default title
 
-g.field 'Change Ad title to default', 'changeValue', type: 'button', tooltip: 'Click here to changhe ad title to default',
+g.field 'Change Ad title to default', 'changeValue', type: 'button', tooltip: 'Click here to change ad title to default',
   onClick: ->
-    g.child('ad_selection').value = "Milk Duds 2019"
+    g.child('ad_title').value = "Milk Duds 2019"
 
 g.field 'Edit', 'edit', type: 'button', tooltip: 'Click here to edit the selected ad',
   onClick: ->


### PR DESCRIPTION
button onclick event doesn't need emit ad and we aren't even sure how that ability emit works. This adds regular way to use button events which does work.